### PR TITLE
Adding try/except to stop keyexception

### DIFF
--- a/run_compose.py
+++ b/run_compose.py
@@ -93,8 +93,11 @@ def main():
     # Print the constructed command (for debugging purposes)
     print("Running command:", " ".join(compose_command))
 
-    # Run the docker compose command
-    subprocess.run(compose_command)
+    try:
+        # Run the docker compose command
+        subprocess.run(compose_command)
+    except KeyboardInterrupt:
+        pass
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
so if one uses a cmd like log -f, and uses ctrl+c to stop following the log, it won't print out the keyException from python afterwards this should fix #34